### PR TITLE
Minor wasm-vips improvements

### DIFF
--- a/app/components/nav-photos.tsx
+++ b/app/components/nav-photos.tsx
@@ -59,6 +59,7 @@ export default function NavPhotos() {
 			const buffer = await fetch(`${image}`).then((resp) => resp.arrayBuffer())
 			const original = vips.Image.jpegloadBuffer(buffer, { autorotate: true })
 			const { width, height } = original
+			original.delete()
 			const photo: Photo = {
 				name: f.name,
 				pid: nanoid(),
@@ -75,6 +76,7 @@ export default function NavPhotos() {
 				no_rotate: false,
 			})
 			const outBuffer = new Uint8Array(img.writeToBuffer('.jpg'))
+			img.delete()
 			photo.blurhash = moulBlurhash(outBuffer)
 
 			const sizes = { xl: 3840, md: 1920 }
@@ -83,6 +85,7 @@ export default function NavPhotos() {
 					no_rotate: false,
 				})
 				const out = new Uint8Array(img.writeToBuffer('.jpg'))
+				img.delete()
 				const body = new Blob([out], { type: 'image/jpeg' })
 				await fetch(`/_moul/r2/${prefix}/${photo.pid}/${k}`, {
 					method: 'PUT',

--- a/app/components/nav-photos.tsx
+++ b/app/components/nav-photos.tsx
@@ -75,7 +75,7 @@ export default function NavPhotos() {
 			const img = vips.Image.thumbnailBuffer(buffer, 16, {
 				no_rotate: false,
 			})
-			const outBuffer = new Uint8Array(img.writeToBuffer('.jpg'))
+			const outBuffer = img.writeToBuffer('.jpg')
 			img.delete()
 			photo.blurhash = moulBlurhash(outBuffer)
 
@@ -84,7 +84,7 @@ export default function NavPhotos() {
 				const img = vips.Image.thumbnailBuffer(buffer, v, {
 					no_rotate: false,
 				})
-				const out = new Uint8Array(img.writeToBuffer('.jpg'))
+				const out = img.writeToBuffer('.jpg')
 				img.delete()
 				const body = new Blob([out], { type: 'image/jpeg' })
 				await fetch(`/_moul/r2/${prefix}/${photo.pid}/${k}`, {

--- a/app/components/nav-profile.tsx
+++ b/app/components/nav-profile.tsx
@@ -113,7 +113,7 @@ export default function NavProfile({ profile }: { profile: Profile }) {
 		const img = vips.Image.thumbnailBuffer(buffer, 16, {
 			no_rotate: false,
 		})
-		const outBuffer = new Uint8Array(img.writeToBuffer('.jpg'))
+		const outBuffer = img.writeToBuffer('.jpg')
 		img.delete()
 		photo.blurhash = moulBlurhash(outBuffer)
 
@@ -127,7 +127,7 @@ export default function NavProfile({ profile }: { profile: Profile }) {
 			const img = vips.Image.thumbnailBuffer(buffer, v, {
 				no_rotate: false,
 			})
-			const out = new Uint8Array(img.writeToBuffer('.jpg'))
+			const out = img.writeToBuffer('.jpg')
 			img.delete()
 			const body = new Blob([out], { type: 'image/jpeg' })
 			await fetch(`/_moul/r2/${prefix}/${photo.pid}/${k}`, {

--- a/app/components/nav-profile.tsx
+++ b/app/components/nav-profile.tsx
@@ -97,6 +97,7 @@ export default function NavProfile({ profile }: { profile: Profile }) {
 		const buffer = await fetch(`${image}`).then((resp) => resp.arrayBuffer())
 		const original = vips.Image.jpegloadBuffer(buffer, { autorotate: true })
 		const { width, height } = original
+		original.delete()
 		const photo: Photo = {
 			name: file.name,
 			pid: nanoid(),
@@ -113,6 +114,7 @@ export default function NavProfile({ profile }: { profile: Profile }) {
 			no_rotate: false,
 		})
 		const outBuffer = new Uint8Array(img.writeToBuffer('.jpg'))
+		img.delete()
 		photo.blurhash = moulBlurhash(outBuffer)
 
 		// this 2 sizes work for now!
@@ -126,6 +128,7 @@ export default function NavProfile({ profile }: { profile: Profile }) {
 				no_rotate: false,
 			})
 			const out = new Uint8Array(img.writeToBuffer('.jpg'))
+			img.delete()
 			const body = new Blob([out], { type: 'image/jpeg' })
 			await fetch(`/_moul/r2/${prefix}/${photo.pid}/${k}`, {
 				method: 'PUT',


### PR DESCRIPTION
Hi @thasophearak,

Thanks for using wasm-vips, I think you're the first to use it in combination with Cloudflare Workers!

I noticed [your Tweet](https://twitter.com/thasophearak/status/1532389124144910336), and took a quick look at how wasm-vips was used. This PR improves a few things:
- Call `delete()` on every image instance that is returned from wasm-vips (see https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828).
- Avoid a `Uint8Array` copy; the resulting byte array is no longer backed by WebAssembly memory (see https://github.com/kleisauke/wasm-vips/commit/185bdc809a483b16d7851215978c08c356b2aca6).

BTW, were there any modifications needed to run this on Cloudflare Workers? I remembered that there was an execution time and a file size limit (see e.g. https://github.com/kleisauke/wasm-vips/issues/2), but perhaps that's no longer an issue.